### PR TITLE
Add darktable for photo management and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,7 @@ These tools are useful when sharing secrets, code snippets or any other kind of 
 - [DigiKam](https://www.digikam.org/) - Awesome Professional Photo Management with the Power of Open Source.
 - [Inkscape](https://inkscape.org/) - Inkscape is a free and open-source vector graphics editor used to create vector images.
 - [ImageGlass](https://imageglass.org/) - ImageGlass is a lightweight software application whose purpose is to help you view images in a clean and intuitive working environment.
+- [darktable](https://www.darktable.org/) - darktable is an open source photography workflow application and raw developer
 
 #### Android
 - [Pocket Paint](https://github.com/Catrobat/Paintroid) - The standard image manipulation app for Catroid.


### PR DESCRIPTION
darktable is a tool designed for amateur and professional photographs. It differs from other tools in the list in multiple ways that make it relevant for a different audience :
- It does both management and editing in a single app. You can think of it as a combination of DigiKam + GIMP
- It accepts raw files : these files are an equivalent of negatives in film photography. Working on these instead of JPEGs adds a lot of editing capabilities and improves the quality of the result
- Editing is non-destructive : all your editions are stored in a text file. What you see in Darktable is a preview of the result. The actual work on your image is only performed when you export it. This allows trial and error without deteriorating your image and/or managing multiple versions of the file by yourself.

It is an alternative to Adobe Lightroom, while GIMP is an alternative to Photoshop.

As for privacy, the software is open source (see [Github repo](https://github.com/darktable-org/darktable)) and released under GPL-3 license. It works completely offline with a minor on-demand exception : you can export images directly to a cloud storage like a Piwigo gallery.

An other alternative (which I don't use personally but also has a very good reputation) is [RawTherapee](https://rawtherapee.com/). To my knowledge, RawTherapee is only a photo editor (no library management), but with the same principles of non-destructive raw processing.